### PR TITLE
Fix Save Gear option not giving binoculars to respawners

### DIFF
--- a/addons/Respawn/functions/fnc_loadSavedGear.sqf
+++ b/addons/Respawn/functions/fnc_loadSavedGear.sqf
@@ -17,7 +17,7 @@
 //if not using gearscript
 private  _var = player getVariable QGVAR(savedgear);
 
-_var params ["_uniform", "_vest", "_headGear", "_backPack", "_googles", "_primaryWeapon", "_secondaryWeapon", "_handGunWeapon", "_uniformItems", "_vestItems", "_backPackItems", "_primaryWeaponItems", "_secondaryWeaponItems", "_handGunItems", "_assignedItems"];
+_var params ["_uniform", "_vest", "_headGear", "_backPack", "_googles", "_primaryWeapon", "_secondaryWeapon", "_handGunWeapon", "_binocularWeapon", "_uniformItems", "_vestItems", "_backPackItems", "_primaryWeaponItems", "_secondaryWeaponItems", "_handGunItems", "_binocularItems", "_assignedItems"];
 
 removeUniform player;
 removeVest player;
@@ -79,6 +79,24 @@ if (_handGunWeapon != "") then {
 			player addHandgunItem _x;
 		};
 	} forEach _handGunItems;
+};
+
+if (_binocularWeapon != "") then {
+	player addWeapon _binocularWeapon;
+
+	//to make sure container is empty
+	{
+		if (_x != "") then {
+			player removeBinocularItem _x;
+		};
+	} forEach (binocularItems player + binocularMagazine player);
+
+	//add original stuff
+	{
+		if (_x != "") then {
+			player addBinocularItem _x;
+		};
+	} forEach _binocularItems;
 };
 
 if (count _assignedItems > 0) then {

--- a/addons/Respawn/functions/fnc_savegear.sqf
+++ b/addons/Respawn/functions/fnc_savegear.sqf
@@ -25,6 +25,7 @@ _googles = goggles player;
 _primaryWeapon = primaryWeapon player;
 _secondaryWeapon = secondaryWeapon player;
 _handGunWeapon = handGunWeapon player;
+_binocularWeapon = binoculars player;
 
 _uniformItems = uniformItems player;
 _vestItems = vestItems player;
@@ -32,7 +33,8 @@ _backPackItems = backPackItems player;
 _primaryWeaponItems = primaryWeaponItems player + primaryWeaponMagazine player;
 _secondaryWeaponItems = secondaryWeaponItems player + secondaryWeaponMagazine player;
 _handGunItems = handgunItems player + handgunMagazine player;
+_binocularItems = binocularItems player + binocularMagazine player;
 
 _assignedItems= assignedItems player;
 
-player setVariable [QGVAR(savedgear), [_uniform, _vest, _headGear, _backPack, _googles, _primaryWeapon, _secondaryWeapon, _handGunWeapon, _uniformItems, _vestItems, _backPackItems, _primaryWeaponItems, _secondaryWeaponItems, _handGunItems, _assignedItems]];
+player setVariable [QGVAR(savedgear), [_uniform, _vest, _headGear, _backPack, _googles, _primaryWeapon, _secondaryWeapon, _handGunWeapon, _binocularWeapon, _uniformItems, _vestItems, _backPackItems, _primaryWeaponItems, _secondaryWeaponItems, _handGunItems, _binocularItems, _assignedItems]];


### PR DESCRIPTION
Fixed version of #12

> This should fix respawners not getting their binoculars (or items within, such as batteries) on respawn when using the `Save Gear` option (an issue with both editor loadouts and mission makers' own gear scripts).
> 
> I have not been able to test this as I'm too noob to build a mod, so please evaluate or hit me on the head if it's wrong.