### PR TITLE
[Hotfix] Respawn position marker error

### DIFF
--- a/addons/Respawn/functions/fnc_marker_update.sqf
+++ b/addons/Respawn/functions/fnc_marker_update.sqf
@@ -15,6 +15,7 @@
 #include "script_component.hpp"
 
 if (!hasInterface) exitWith { };
+if (playerSide isEqualTo sideUnknown) exitWith { }; // Exit if a virtual entity (IE zeus)
 private _currentRespawnPos = switch (playerSide) do {
 	case west: {	
 		"tun_respawn_west"


### PR DESCRIPTION
If utilizing virtual entities such as a zeus module, the respawn marker doesn't account for `sideUnknown`. Weirdly enough, it prevents the rest of our framework from initializing as well.

This PR adds a check to exit the respawn marker creation if you're a zeus.

![image](https://github.com/tuntematonjr/Tun-Respawn-System/assets/9407533/283df175-f1ba-4ae0-96d0-400c601633ca)

![image](https://github.com/tuntematonjr/Tun-Respawn-System/assets/9407533/932c0e96-ae7f-47f7-bbbd-041702987862)
